### PR TITLE
fixed the git logo and the onclick

### DIFF
--- a/css/linktree.css
+++ b/css/linktree.css
@@ -9,6 +9,9 @@ body
 
 /* Content Box
 ---------------------*/
+.feature-box-1:hover{
+  cursor: pointer;
+}
 .feature-box-1 {
   padding: 32px;
   box-shadow: 0 0 30px rgba(31, 45, 61, 0.125);

--- a/index.html
+++ b/index.html
@@ -32,11 +32,10 @@
         <div class="row">
             <!-- Content Box Begin -->
             <div class="col-sm-6 col-lg-4">
-                <div class="feature-box-1">
+                <div class="feature-box-1" onclick="location.href='./cpp/index.html'">
                     <div class="icon">
                         <img src="https://img.icons8.com/color/48/000000/c-plus-plus-logo.png"/>
                     </div>
-                    <a href="./cpp/index.html" style="text-decoration: none;">
                         <div class="feature-content">
                             <h3>C++</h3>
                             <p>The C++ cheatsheet focuses both on the language as well as common classes from the standard library.</p>
@@ -48,11 +47,10 @@
 
             <!-- Content Box Begin -->
             <div class="col-sm-6 col-lg-4">
-                <div class="feature-box-1">
+                <div class="feature-box-1" onclick="location.href='./git/index.html'">
                     <div class="icon">
-                        <img src="https://img.icons8.com/nolan/64/git.png"/>
+                        <img src="https://git-scm.com/images/logos/downloads/Git-Icon-Black.svg" height="50"/>
                     </div>
-                    <a href="./git/index.html" style="text-decoration: none;">
                         <div class="feature-content">
                             <h3>Git</h3>
                             <p>This cheat sheet features the most important and commonly used Git commands for easy reference.</p>


### PR DESCRIPTION
Fixed the git logo and the onclick now works on the whole box as mentioned in the following issue:https://github.com/IEEE-SB-GECBH/Cheatsheet-Hacktoberfest2022/issues/6 @gouthamrajesh 
![image](https://user-images.githubusercontent.com/96713176/194573962-902a3e5c-7acb-4b79-ad33-302c5fe32220.png)
